### PR TITLE
Set group ownership in cachefix cron

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
     user: root
     job: >-
       find /var/nginx/cache/ -type d -exec chmod -v 770 {} \; &>/dev/null ;
+      find /var/nginx/cache/ -type d -exec chgrp -v nginx {} \; &/dev/null ;
       find /var/nginx/cache/ -type f -exec chmod -v 660 {} \; &>/dev/null
     cron_file: cachefix
 


### PR DESCRIPTION
In some cases, group ownership of the sitecache directory reverts to root. Add a chgrp command to the cachefix cron to avoid this issue